### PR TITLE
Add random cell selection and fix hierarchical target

### DIFF
--- a/app/include/ldg/util/tree_functions.hpp
+++ b/app/include/ldg/util/tree_functions.hpp
@@ -6,6 +6,7 @@
 #include "app/include/ldg/model/quad_assignment_tree.hpp"
 #include "app/include/ldg/util/tree_traversal/tree_walker.hpp"
 #include "app/include/ldg/util/math.hpp"
+#include "app/include/program/random.hpp"
 
 #include <cassert>
 
@@ -69,10 +70,10 @@ namespace ldg
      * @tparam VectorType
      */
     template<typename VectorType>
-    void randomizeAssignment(QuadAssignmentTree<VectorType> &quad_tree, size_t seed)
+    void randomizeAssignment(QuadAssignmentTree<VectorType> &quad_tree)
     {
         auto &assignment = quad_tree.getAssignment();
-        std::shuffle(assignment.begin(), assignment.begin() + quad_tree.getNumRows() * quad_tree.getNumCols(), std::mt19937(seed));
+        std::shuffle(assignment.begin(), assignment.begin() + quad_tree.getNumRows() * quad_tree.getNumCols(), program::RANDOMIZER);
     }
 
     /**

--- a/app/include/program/input/input.hpp
+++ b/app/include/program/input/input.hpp
@@ -140,7 +140,6 @@ namespace program
     {
         return {
             result["randomize"].as<bool>(),
-            result["seed"].as<size_t>(),
             result["partition_swaps"].as<bool>(),
             result["ssm_mode"].as<bool>(),
             ldg::mapFunctionTypeToFunction<VectorType>(static_cast<ldg::DistanceFunctionType>(result["distance_function"].as<size_t>()))

--- a/app/include/program/input/input_args.hpp
+++ b/app/include/program/input/input_args.hpp
@@ -30,7 +30,7 @@ namespace program
            ("min_distance_change", "Minimum distance change for convergence.", cxxopts::value<double>()->default_value("0.00001"))
            ("distance_change_factor", "Distance change ratio change factor per pass.", cxxopts::value<double>()->default_value("1"))
            ("iterations_change_factor", "Maximum number of iterations change factor per pass.", cxxopts::value<double>()->default_value("1"))
-           ("seed", "Randomization seed.", cxxopts::value<size_t>()->default_value(std::to_string(std::rand())))
+           ("seed", "Randomization seed.", cxxopts::value<size_t>()->default_value(std::to_string(std::time(0))))
            ("partition_swaps", "Enable partition swaps.", cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
            ("randomize", "Randomize the assignment at the start.", cxxopts::value<bool>()->default_value("true")->implicit_value("true"))
            ("parent_type", "Type of parent representation to use. Options are: Normalized average: 0, Minimum child: 1", cxxopts::value<size_t>()->default_value("0"))

--- a/app/include/program/random.hpp
+++ b/app/include/program/random.hpp
@@ -1,0 +1,10 @@
+#ifndef LDG_SSM_RANDOM_HPP
+#define LDG_SSM_RANDOM_HPP
+
+#include <random>
+
+namespace program {
+    static std::mt19937 RANDOMIZER;
+}
+
+#endif //LDG_SSM_RANDOM_HPP

--- a/app/include/program/run.hpp
+++ b/app/include/program/run.hpp
@@ -30,7 +30,7 @@ namespace program
         ldg::assertUniqueAssignment(quad_tree);
         std::cout << "Initial HND: " << ldg::computeHierarchyNeighborhoodDistance(0, sort_options.distance_function, quad_tree) << std::endl;
         if (sort_options.randomize_assignment) {
-            ldg::randomizeAssignment(quad_tree, sort_options.randomization_seed);
+            ldg::randomizeAssignment(quad_tree);
             std::cout << "Randomized HND: " << ldg::computeHierarchyNeighborhoodDistance(0, sort_options.distance_function, quad_tree) << std::endl;
         }
         std::cout << std::endl;

--- a/app/include/program/sort_options.hpp
+++ b/app/include/program/sort_options.hpp
@@ -18,7 +18,6 @@ namespace program
     struct SortOptions
     {
         bool randomize_assignment;
-        size_t randomization_seed;
         bool use_partition_swaps;
         bool ssm_mode;
         std::function<double(std::shared_ptr<VectorType>, std::shared_ptr<VectorType>)> distance_function;

--- a/app/include/self_sorting_map/exchanges.hpp
+++ b/app/include/self_sorting_map/exchanges.hpp
@@ -22,7 +22,7 @@ namespace ssm
         std::vector<ldg::CellPosition> &nodes,
         ldg::QuadAssignmentTree<VectorType> &quad_tree,
         std::function<double(std::shared_ptr<VectorType>, std::shared_ptr<VectorType>)> distance_function,
-        std::vector<std::shared_ptr<VectorType>> &target_map
+        std::vector<std::vector<std::shared_ptr<VectorType>>> &target_map
     )
     {
         using namespace ldg;
@@ -60,10 +60,12 @@ namespace ssm
         do {
             double distance = 0.;
             for (size_t idx = 0; idx < num_nodes; ++idx) {
-                distance += distance_function(
-                    node_data[permutation[idx]],
-                    target_map[nodes[idx].index]
-                );
+                for (auto &target : target_map[nodes[idx].index]) {
+                    distance += distance_function(
+                        node_data[permutation[idx]],
+                        target
+                    );
+                }
             }
 
             // Better permutation, save it

--- a/app/include/self_sorting_map/method.hpp
+++ b/app/include/self_sorting_map/method.hpp
@@ -81,12 +81,11 @@ namespace ssm
 
         // Main loop
         long height = ssm_mode ? getSSMStartHeight(quad_tree) : quad_tree.getDepth() - 2;
-        long min_height = ssm_mode ? 1 : 0;
         size_t num_exchanges;
         std::string reason;
         std::pair<size_t, size_t> normal_pass_pairings{ 2, 2 }; // Separate X-Y passes can be enabled by tweaking this, but this is not needed here.
 
-        for (; height >= min_height; --height) {
+        for (; height > 0; --height) {
             size_t iterations = 0;
 
             do {
@@ -103,7 +102,7 @@ namespace ssm
                 distance = new_distance;
                 new_distance = computeHierarchyNeighborhoodDistance(0, distance_function, quad_tree);
 
-                if (iterations_between_checkpoint > 0 && iterations % iterations_between_checkpoint == 0) {
+                if (iterations_between_checkpoint > 0 && iterations > 0 && iterations % iterations_between_checkpoint == 0) {
                     export_settings.file_name = "height-" + std::to_string(height) + "-it(" + std::to_string(iterations) + ')';
                     program::exportQuadTree(quad_tree, distance_function, export_settings);
                 }

--- a/app/include/self_sorting_map/method.hpp
+++ b/app/include/self_sorting_map/method.hpp
@@ -80,18 +80,20 @@ namespace ssm
         double new_distance = distance;
 
         // Main loop
-        size_t height = ssm_mode ? getSSMStartHeight(quad_tree) : quad_tree.getDepth() - 2;
+        long height = ssm_mode ? getSSMStartHeight(quad_tree) : quad_tree.getDepth() - 2;
+        long min_height = ssm_mode ? 1 : 0;
         size_t num_exchanges;
         std::string reason;
         std::pair<size_t, size_t> normal_pass_pairings{ 2, 2 }; // Separate X-Y passes can be enabled by tweaking this, but this is not needed here.
 
-        for (; height > 0; --height) {
+        for (; height >= min_height; --height) {
             size_t iterations = 0;
 
             do {
                 num_exchanges = 0;
                 num_exchanges += optimizePartitions(quad_tree, distance_function, height, 0, normal_pass_pairings, ssm_mode, false);
-                num_exchanges += optimizePartitions(quad_tree, distance_function, height, 0, normal_pass_pairings, ssm_mode, true);
+                if (height < quad_tree.getDepth() - 2)
+                    num_exchanges += optimizePartitions(quad_tree, distance_function, height, 0, normal_pass_pairings, ssm_mode, true);
 
                 if (use_partition_swaps && height > 1) {
                     num_exchanges += optimizePartitions(quad_tree, distance_function, height, height - 1, normal_pass_pairings, ssm_mode, false);

--- a/app/include/self_sorting_map/partitions.hpp
+++ b/app/include/self_sorting_map/partitions.hpp
@@ -63,7 +63,7 @@ namespace ssm
     size_t performPartitionExchanges(
         ldg::QuadAssignmentTree<VectorType> &quad_tree,
         std::function<double(std::shared_ptr<VectorType>, std::shared_ptr<VectorType>)> distance_function,
-        std::vector<std::shared_ptr<VectorType>> &target_map,
+        std::vector<std::vector<std::shared_ptr<VectorType>>> &target_map,
         std::array<std::vector<long>, 4> &cell_pairings_array,
         const size_t comparison_height,
         const long partition_len,

--- a/app/include/self_sorting_map/target/highest_parent_hierarchy.hpp
+++ b/app/include/self_sorting_map/target/highest_parent_hierarchy.hpp
@@ -22,7 +22,7 @@ namespace ssm
      */
     template<typename VectorType>
     void loadHighestParentHierarchyTargets(
-        std::vector<std::shared_ptr<VectorType>> &target_map,
+        std::vector<std::vector<std::shared_ptr<VectorType>>> &target_map,
         ldg::QuadAssignmentTree<VectorType> &quad_tree,
         const size_t partition_height,
         const size_t comparison_height,
@@ -54,7 +54,7 @@ namespace ssm
             size_t max_x = std::min(min_x + partition_len, comparison_height_dims.second);
             for (size_t y = min_y; y < max_y; ++y) {
                 for (size_t x = min_x; x < max_x; ++x) {
-                    target_map[rowMajorIndex(y, x, comparison_height_dims.second)] = target;
+                    target_map[rowMajorIndex(y, x, comparison_height_dims.second)].push_back(target);
                 }
             }
         }

--- a/app/include/self_sorting_map/target/partition_neighbourhood_target.hpp
+++ b/app/include/self_sorting_map/target/partition_neighbourhood_target.hpp
@@ -22,7 +22,7 @@ namespace ssm
      */
     template<typename VectorType>
     void loadPartitionNeighbourhoodTargets(
-        std::vector<std::shared_ptr<VectorType>> &target_map,
+        std::vector<std::vector<std::shared_ptr<VectorType>>> &target_map,
         ldg::QuadAssignmentTree<VectorType> &quad_tree,
         const size_t partition_height,
         const size_t comparison_height,
@@ -65,7 +65,7 @@ namespace ssm
             max_x = std::min(min_x + partition_len, comparison_height_dims.second);
             for (size_t y = min_y; y < max_y; ++y) {
                 for (size_t x = min_x; x < max_x; ++x) {
-                    target_map[rowMajorIndex(y, x, comparison_height_dims.second)] = target;
+                    target_map[rowMajorIndex(y, x, comparison_height_dims.second)].push_back(target);
                 }
             }
 

--- a/app/include/self_sorting_map/target/target_type.hpp
+++ b/app/include/self_sorting_map/target/target_type.hpp
@@ -9,12 +9,8 @@ namespace ssm
      */
     enum TargetType
     {
-        AGGREGATE_HIERARCHY,            // Aggregate parents in the hierarchy
         HIGHEST_PARENT_HIERARCHY,       // Highest unique parent per partition
-        AGGREGATE_HIERARCHY_4C,         // 4-connected variant of AGGREGATE_HIERARCHY
-        HIGHEST_PARENT_HIERARCHY_4C,    // 4-connected variant of HIGHEST_PARENT_HIERARCHY
-        PARTITION_NEIGHBOURHOOD,        // Neighbourhood of parent aggregates
-        CELL_NEIGHBOURHOOD,             // Direct neighbourhood per cell.
+        PARTITION_NEIGHBOURHOOD         // Neighbourhood of parent aggregates
     };
 }
 

--- a/app/include/self_sorting_map/targets.hpp
+++ b/app/include/self_sorting_map/targets.hpp
@@ -25,7 +25,7 @@ namespace ssm
      * @return  A num_rows x num_cols map at the comparison height where each index contains the targets for that node.
      */
     template<typename VectorType>
-    std::vector<std::shared_ptr<VectorType>> getTargetMap(
+    std::vector<std::vector<std::shared_ptr<VectorType>>> getTargetMap(
         const TargetType target_type,
         ldg::QuadAssignmentTree<VectorType> &quad_tree,
         size_t partition_height,
@@ -34,7 +34,7 @@ namespace ssm
     )
     {
         auto comparison_height_dims = quad_tree.getBounds(comparison_height).second;
-        std::vector<std::shared_ptr<VectorType>> target_map(comparison_height_dims.first * comparison_height_dims.second);
+        std::vector<std::vector<std::shared_ptr<VectorType>>> target_map(comparison_height_dims.first * comparison_height_dims.second);
 
         switch (target_type) {
             case HIGHEST_PARENT_HIERARCHY:

--- a/app/src/ldg_ssm.cpp
+++ b/app/src/ldg_ssm.cpp
@@ -9,7 +9,6 @@
 #include "app/include/program/input/input_args.hpp"
 #include "app/include/program/input/input.hpp"
 
-
 /**
  * Entrypoint of the application. Handles input and then delegates to the runner.
  *
@@ -30,6 +29,8 @@ int main(int argc, const char **argv)
         auto schedule = program::loadScheduleFromInput(parse_result);
         auto sort_options = program::loadSortOptionsFromInput<Eigen::VectorXd>(parse_result);
         auto export_settings = program::loadExportSettingsFromInput(parse_result);
+        program::RANDOMIZER = std::mt19937(parse_result["seed"].as<size_t>());
+
         program::run(quad_tree, schedule, sort_options, export_settings);
     } catch (const std::exception &exception) {
         std::cerr << "ldg_ssm: " << exception.what() << std::endl;


### PR DESCRIPTION
Add random cell selection when comparing partitions to improve robustness against local minima. Additionally adds back the use of multiple targets to allow the LDG-SSM sorting to optimize for both hierarchy and neighbourhood.